### PR TITLE
Added Windows Support to RTCorePlatform.cpp

### DIFF
--- a/src/RTCorePlatform.cpp
+++ b/src/RTCorePlatform.cpp
@@ -36,7 +36,48 @@ extern "C" {
 
 #elif defined(WIN32) || defined(_WIN32) || defined(__WIN32) && !defined(__CYGWIN__)
 
-#include 
+#include <Windows.h>
+
+extern "C" {
+  void get_micros_uli(ULARGE_INTEGER& uli)
+  {
+    SYSTEMTIME st;
+    GetSystemTime(&st);
+    FILETIME ft;
+    SystemTimeToFileTime(&st, &ft);
+    uli.HighPart = ft.dwHighDateTime;
+    uli.LowPart = ft.dwLowDateTime;
+  }
+
+  uint64_t get_micros_ull()
+  {
+    ULARGE_INTEGER uli;
+    get_micros_uli(uli);
+    return (uint64_t)(uli.QuadPart / 10ull);
+  }
+  uint32_t millis() {
+    auto us_ull = get_micros_ull();
+    auto ms_ull = us_ull / 1000ull;
+    return (uint32_t)ms_ull;
+  }
+
+  uint32_t micros() {
+    return (uint32_t)(get_micros_ull);
+  }
+
+  void delay(uint32_t ms) {
+    Sleep(ms);
+  }
+
+  void delayMicroseconds(uint32_t us) {
+    if (us <= 1000.f) {
+      delay(1);
+    }
+    else {
+      delay(us / 1000.f);
+    }
+  }
+}
 
 #endif
 


### PR DESCRIPTION
Primary time support comes from get_micros_uli which uses GetSystemTime and SystemTimeToFileTime

delay uses Sleep() and delayMicroseonds() simply
uses Sleep() with 1 millisecond sleep being the minimum supported.  Busy microsecond waits are possible,
but RTCorePlatform is not designed for bit-bang
level accuracy on Windows targets